### PR TITLE
Remove Pipfile and Pipefile.lock if present

### DIFF
--- a/schedule_performance_benchmarks.py
+++ b/schedule_performance_benchmarks.py
@@ -176,7 +176,8 @@ def schedule_performance_benchmarks(
     verify_script_framework_compatibility(framework=framework, script=benchmark)
     _LOGGER.info(f"Platform/Image selected is {image}")
     _LOGGER.info(f"Framework/Version selected is: {framework}:{framework_version}")
-    _LOGGER.info(f"Performance test selected is: {index_url}")
+    _LOGGER.info(f"Index source is: {index_url}")
+    _LOGGER.info(f"Performance test selected is: {benchmark}")
     _LOGGER.info(f"Number of inspections requested is: {count}")
     specification = create_amun_api_input(
         image=image,

--- a/schedule_performance_benchmarks.py
+++ b/schedule_performance_benchmarks.py
@@ -78,6 +78,16 @@ def create_pipfile_and_pipfile_lock_inputs(
     framework: str, framework_version: str, index_url: str
 ):
     """Create requirements and requirements_locked"""
+    if os.path.exists("{}".format("./Pipfile")):
+        os.remove("{}".format("./Pipfile"))
+    else:
+        _LOGGER.info("Pipfile was not present!")
+
+    if os.path.exists("{}".format("./Pipfile.lock")):
+        os.remove("{}".format("./Pipfile.lock"))
+    else:
+        _LOGGER.info("Pipfile.lock was not present!")
+
     if index_url == "https://pypi.python.org/simple":
         _LOGGER.info(
             " ".join(
@@ -130,9 +140,14 @@ def create_pipfile_and_pipfile_lock_inputs(
         )
 
     if os.path.exists("{}".format("./Pipfile")):
-        _LOGGER.info(f"Pipfile \n\n {pipfile2dict(pipfile_path='./Pipfile')}")
+        _LOGGER.info("Pipfile was created!")
     else:
-        _LOGGER.error("Pipfile not created!")
+        _LOGGER.error("Pipfile was not created!")
+
+    if os.path.exists("{}".format("./Pipfile.lock")):
+        _LOGGER.info("Pipfile.lock was created!")
+    else:
+        _LOGGER.error("Pipfile.lock was not created!")
 
 
 def verify_script_framework_compatibility(framework: str, script: str):


### PR DESCRIPTION
Added functionality, Remove Pipfile and Pipefile.lock if present, otherwise it would use the Pipfile and especially the Pipfile.lock already created even if the input for scheduling are wrong.

Added other info in output.

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>