### PR TITLE
Add OWNERS file to this repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - codificat
+  - fridex
+  - goern
+  - harshad16
+  - kpostoffice
+  - mayaCostantini
+  - pacospace
+reviewers:
+  - codificat
+  - fridex
+  - goern
+  - harshad16
+  - kpostoffice
+  - mayaCostantini
+  - pacospace


### PR DESCRIPTION
There was no OWNERS file for prow in this repo, this adds one.

Initially added everyone in the team as approver and potential reviewer, let me know if we should trim that for this repo.
