### PR TITLE
Top PyPI Packages: Use 30-days data, 365 is no longer available

### DIFF
--- a/schedule_most_popular.py
+++ b/schedule_most_popular.py
@@ -28,7 +28,7 @@ daiquiri.setup(level=logging.INFO)
 
 _LOGGER = logging.getLogger(__name__)
 
-_POPULAR_PYPI_PACKAGES = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-365-days.json"
+_POPULAR_PYPI_PACKAGES = "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json"
 
 
 def schedule_most_popular(management_api_url: str, api_secret: str, *, offset: int, count: int) -> None:


### PR DESCRIPTION
## Related Issues and Dependencies
<!-- Mention any relevant issue/PR here.
In particular, if this PR resolves issue XYZ, make sure you add a line:
Fixes: #XYZ -->

https://hugovk.github.io/top-pypi-packages/

## This introduces a breaking change
<!-- Leave one of the options -->

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- No

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
<!-- Provide a summary of your changes here. -->

A fix

### Description
<!--- Describe your changes in detail here. -->

I needed to remove the 365-day data from https://hugovk.github.io/top-pypi-packages/ because it was using more quota than available, so let's use the 30-day one instead.

Let's also use the slightly smaller minified version.

Re: https://github.com/hugovk/top-pypi-packages/pull/21, https://github.com/hugovk/top-pypi-packages/pull/20, https://github.com/hugovk/top-pypi-packages/issues/19.

